### PR TITLE
ci: always run Tests workflow and gate jobs on changed paths

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,9 +4,14 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   changes:
@@ -18,9 +23,13 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             node:
-              - '!(.gitignore|LICENSE|README.md)'
+              - '**'
+              - '!.gitignore'
+              - '!LICENSE'
+              - '!README.md'
 
   check-attw:
     needs: changes

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,21 +3,28 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - .gitignore
-      - LICENSE
-      - README.md
   pull_request:
-    paths-ignore:
-      - .gitignore
-      - LICENSE
-      - README.md
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      node: ${{ steps.filter.outputs.node }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            node:
+              - '!(.gitignore|LICENSE|README.md)'
+
   check-attw:
+    needs: changes
+    if: needs.changes.outputs.node == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -33,6 +40,8 @@ jobs:
         run: npx -p @arethetypeswrong/cli attw --pack --profile esm-only .
 
   test-coverage:
+    needs: changes
+    if: needs.changes.outputs.node == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -54,6 +63,7 @@ jobs:
 
   ci-gate:
     needs:
+      - changes
       - check-attw
       - test-coverage
     if: always()


### PR DESCRIPTION
## Summary

Branch protection requires the `ci-gate` status check from the Tests workflow, but the workflow had `paths-ignore` filters on its triggers, so it never ran for PRs that only touch ignored files (e.g. some renovate PRs). With the workflow not triggered, the required `ci-gate` check never appears and those PRs are stuck forever.

The workflow now always runs, and change detection moved into a `changes` job using `dorny/paths-filter`. The single `node` filter reproduces the previous `paths-ignore` semantics with a negation pattern (`!(.gitignore|LICENSE|README.md)`), and the `check-attw` and `test-coverage` jobs are gated on it. Skipped jobs count as success for `ci-gate`, so the required check always resolves.

Same pattern as the Check workflow in apitally/cloud and apitally/cli#52.

## Validation

This PR touches the workflow file itself, which matches the filter, so the gated jobs run here. The skipped-jobs path is exercised by PRs that only touch the ignored files once this is merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always run the Tests workflow and gate jobs on changed paths so the required `ci-gate` status check always appears and PRs no longer get stuck.

- **Bug Fixes**
  - Use a `changes` job with `dorny/paths-filter` to include any change except `.gitignore`, `LICENSE`, `README.md` (correct filter semantics).
  - Gate `check-attw` and `test-coverage` on `changes` or `workflow_dispatch`, skipping when only ignored files change.
  - Make `ci-gate` depend on `changes`, `check-attw`, and `test-coverage` with `if: always()` so skipped jobs count as success.
  - Limit concurrency cancellation to pull_request events only.
  - Declare minimal permissions: `contents: read`, `pull-requests: read`.

<sup>Written for commit ec7f714434feea56f63ece9e1e3c2e4d461fa480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/apitally/apitally-js-serverless/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

